### PR TITLE
Build for MAC Arm; Upgrade to 2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.DS_Store
+build/
+standalone/bld/*
+dist/
+plugin.dylib
+plugin-arm64.dylib
+plugin.so
+plugin.dll
+standalone/exe_*
+pynb/.ipynb_checkpoints/*
+src/#*
+src/.#*
+.idea
+dep/
+cmake-build*

--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,9 @@ DISTRIBUTABLES += res
 DISTRIBUTABLES += $(wildcard LICENSE*)
 
 # Static libs
-libsamplerate := dep/lib/libsamplerate.a
-OBJECTS += $(libsamplerate)
 
 # Dependencies
 DEP_LOCAL := dep
-DEPS += $(libsamplerate)
-
-$(libsamplerate):
-	cd dep && $(WGET) http://www.mega-nerd.com/SRC/libsamplerate-0.1.9.tar.gz
-	cd dep && $(UNTAR) libsamplerate-0.1.9.tar.gz
-	cd dep/libsamplerate-0.1.9 && $(CONFIGURE)
-	cd dep/libsamplerate-0.1.9/src && $(MAKE)
-	cd dep/libsamplerate-0.1.9/src && $(MAKE) install
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 RACK_DIR ?= ../..
 
 # FLAGS will be passed to both the C and C++ compiler
-FLAGS += -Idep/include
+FLAGS +=
 CFLAGS +=
 CXXFLAGS +=
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "stocaudio",
   "name": "stocaudio",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "GPL-3.0-or-later",
   "author": "Alessandro Petrone",
   "authorEmail": "contact@stocaudio.com",


### PR DESCRIPTION
This fixes the stocaudio-module package to build for Mac ARM.

To update for Mac ARM in the VCV Rack library, if you would like to

1. Merge this change into your rack 2 branch
2. Go to https://github.com/VCVRack/library/issues/597 and post the new version number (2.0.2) and git hash (whatever the hash is post merge)

Hope this is helpful!

Thanks